### PR TITLE
Fixing style and WP Customize menu

### DIFF
--- a/assets/css/photoswipe.css
+++ b/assets/css/photoswipe.css
@@ -9,7 +9,7 @@
     .woocommerce #content div.product div.thumbnails a, .woocommerce div.product div.thumbnails a, .woocommerce-page #content div.product div.thumbnails a, .woocommerce-page div.product div.thumbnails a {width:100% !important;}
 
     body {
-  margin-top: 50px;
+  margin-top: 0px;
 }
 .pswp__zoom-wrap {
   text-align: center;
@@ -96,7 +96,6 @@ html {
     width: 100%;
 }
 body{
-    display: table;
     height:100%;
     width: 100%;
 }

--- a/embed-videos-for-product-image-gallery-using-woocommerce.php
+++ b/embed-videos-for-product-image-gallery-using-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: Embed Videos For Product Image Gallery Using WooCommerce
  * Plugin URL: http://wordpress.org/plugins/embed-videos-product-image-gallery-woocommerce
  * Description:  Embed videos to product gallery alongwith images on product page of WooCommerce.
- * Version: 2.9
+ * Version: 2.9.1
  * Author: ZealousWeb
  * Author URI: http://zealousweb.com
  * Developer: The Zealousweb Team
@@ -27,7 +27,7 @@ if ( !defined( 'ABSPATH' ) ) exit;
  */
 
 if ( !defined( 'WCEVZW_VERSION' ) ) {
-	define( 'WCEVZW_VERSION', '2.9' ); // Version of plugin
+	define( 'WCEVZW_VERSION', '2.9.1' ); // Version of plugin
 }
 
 if ( !defined( 'WCEVZW_FILE' ) ) {

--- a/inc/admin/wcevzw.admin.php
+++ b/inc/admin/wcevzw.admin.php
@@ -110,7 +110,9 @@ function embed_videos_init() {
 add_filter( 'attachment_fields_to_edit', 'wcevzw_woo_embed_video', 20, 2);
 function wcevzw_woo_embed_video( $form_fields, $attachment ) {
 
-	$post_id = (int) $_GET[ 'post' ];
+	if (! $post_id = (int) ($_GET['post'] ?? null)) {
+		return $form_fields;
+	}
 	$nonce = wp_create_nonce( 'bdn-attach_' . $attachment->ID );
 	$attach_image_action_url = admin_url( "media-upload.php?tab=library&post_id=$post_id" );
 


### PR DESCRIPTION
On our instance of Woocommerce, trying to get the `$_GET['post']` without checking if `post` key is set on `$_GET` array causes the Wordpress Customize interface to crash and not display anything. Hence I've added this quick check. It doesn't change anything feature-wise.

The style was also too aggressively set. In particular, using `display: table` on `body` breaks many layouts.

I've bumped the version assuming SemVer.

Regards.